### PR TITLE
More filtering options

### DIFF
--- a/Languages/English/Keyed/English.xml
+++ b/Languages/English/Keyed/English.xml
@@ -122,14 +122,18 @@ A variable should be named the same way parameters are - lowercase, no . or " in
 	<CD.M.infocard.basic.tutorials.doXTimes.description>Any equations you put into "Do X Times" will be resolved down into a number, rather than remembered like in "Do Until X".
 	
 This is done so you can make one-time calculations in the field, like colonists * 3, without the bill running forever.</CD.M.infocard.basic.tutorials.doXTimes.description>
-	
+	<CD.M.infocard.basic.tutorials.stacks>Counting Stacks</CD.M.infocard.basic.tutorials.stacks>
+	<CD.M.tutorial.basic.tutorials.stacks.description>You can also search for the count of Things in terms of stacks by adding ".stacks". This is only applicable to searching for Things.</CD.M.tutorial.basic.tutorials.stacks.description>
+
+
 	<CD.M.infocard.basic.examples.pawns>"colonists" * 2</CD.M.infocard.basic.examples.pawns>
 	<CD.M.infocard.basic.examples.pawns.description>Get the number of colonists you have, times two. Useful for things like clothing or weapon production.</CD.M.infocard.basic.examples.pawns.description>
 	<CD.M.infocard.basic.examples.intake>"pawns.intake" * 5</CD.M.infocard.basic.examples.intake>
 	<CD.M.infocard.basic.examples.intake.description>The amount of nutritional intake all pawns in your colony need for 5 days. Meals have 0.9 nutrition, so this is rough estimate for how many meals you need.</CD.M.infocard.basic.examples.intake.description>
 	<CD.M.infocard.basic.examples.meals>"categories.meals"</CD.M.infocard.basic.examples.meals>
 	<CD.M.infocard.basic.examples.meals.description>How many meals your colony has - simple, fine, luxury, packaged... Useful in the "Custom item count" field.</CD.M.infocard.basic.examples.meals.description>
-
+	<CD.M.infocard.basic.examples.stacks>"granite blocks.stacks"</CD.M.infocard.basic.examples.stacks>
+	<CD.M.infocard.basic.examples.stacks.description>How many stacks of granite blocks your colony has. This is equivalent to ["granite blocks" / "prefab.granite blocks.stack limit"].</CD.M.infocard.basic.examples.stacks.description>
 	
 	<CD.M.tutorial.searching.things>Searching Things</CD.M.tutorial.searching.things>
 	<CD.M.tutorial.searching.things.description>You can search any Thing in the game such as "slate blocks", ostriches, "compacted steel", etc.
@@ -145,7 +149,7 @@ Compacted steel -> "compacted steel"
 Medicine x5 -> "medicine"
 Go-juice -> "go-juice"
 Uranium mace (legendary) -> mace</CD.M.tutorial.searching.things.description>
-
+	
 	<CD.M.tutorial.searching.stats>Searching Thing Stats</CD.M.tutorial.searching.stats>
 	<CD.M.tutorial.searching.stats.description>Things have stats like "market value", "nutrition", "mech bandwidth". This mod supports two types of stat searching.
 
@@ -172,7 +176,7 @@ Eggs (unfert.) -> "cat eggs (unfert_)"</CD.M.tutorial.searching.categories.descr
 
 	<CD.M.tutorial.searching.traits>Searching traits</CD.M.tutorial.searching.traits>
 	<CD.M.tutorial.searching.traits.description>You can search any trait on any pawn group, such as "pawns.traits.jogger", "colonists.traits.nudist", "colonists.traits.gay"</CD.M.tutorial.searching.traits.description>
-
+	
 	<!-- Pawn groups -->
 	<CD.M.pawn.group.pawns.description>Alias: pwn
 Number of owned pawns on the map the bill is contained in.</CD.M.pawn.group.pawns.description>
@@ -263,4 +267,12 @@ The full list of traits can be seen at the bottom of this tab.</CD.M.infocard.pa
 	<CD.M.infocard.categories>Categories</CD.M.infocard.categories>
 	<CD.M.infocard.categories.description>You can search any category of things in game, such as "categories.raw food", "categories.textiles", "c.meals", etc. Categories can be seen in any stockpile or bill menu.</CD.M.infocard.categories.description>
 	
+	<CD.M.infocard.compositable_loadouts>Compositable Loadouts</CD.M.infocard.compositable_loadouts>
+	<CD.M.infocard.compositable_loadouts.description>You can search by pawns assigned a given tag using the selector "lt" or "loadout tags". In the event of multiple tags with identical names, the first one should be used.</CD.M.infocard.compositable_loadouts.description>
+	
+	<CD.M.infocard.compositable_loadouts.tag>"lt.{0}"</CD.M.infocard.compositable_loadouts.tag>
+	<CD.M.infocard.compositable_loadouts.tag.description>Number of pawns on map with the loadout tag "{0}".</CD.M.infocard.compositable_loadouts.tag.description>
+
+	<CD.M.infocard.compositable_loadouts.no_tags>No tags found</CD.M.infocard.compositable_loadouts.no_tags>
+	<CD.M.infocard.compositable_loadouts.no_tags.description>No tags have been created yet, create some tags to see examples.</CD.M.infocard.compositable_loadouts.no_tags.description>
 </LanguageData>

--- a/Source/CachedMapData.cs
+++ b/Source/CachedMapData.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using CrunchyDuck.Math.MathFilters;
+using Inventory;
 using ProjectRimFactory;
 using ProjectRimFactory.Common.HarmonyPatches;
 using ProjectRimFactory.Storage;
@@ -78,6 +79,12 @@ namespace CrunchyDuck.Math {
 					// pawn
 					else if (PawnFilter.filterMethods.ContainsKey(command) || pawns_dict.ContainsKey(command)) {
 						filter = new PawnFilter(bc);
+					}
+					// compositable loadouts; Has to be extracted to separate methods because otherwise it throws exceptions when run without the mod.
+					else if (Math.compositableLoadoutsSupportEnabled && IsCompositableLoadoutCommand(command)) {
+						if (i + 1 >= commands.Length && GetCompositableLoadoutFilter(commands[++i], bc, ref filter))
+							continue;
+						return false;
 					}
 					// Can't find filter.
 					else {
@@ -226,6 +233,16 @@ namespace CrunchyDuck.Math {
 			}
 
 			return things;
+		}
+
+		private static bool IsCompositableLoadoutCommand(string command) {
+			return CompositableLoadoutTagsFilter.names.Contains(command);
+		}
+		private static bool GetCompositableLoadoutFilter(string command, BillComponent bc, ref MathFilter filter) {
+			if (!CompositableLoadoutTagsFilter.TryFindTagByName(command, out Tag tag))
+				return false;
+			filter = new CompositableLoadoutTagsFilter(bc, tag);
+			return true;
 		}
 
 	}

--- a/Source/Dialogs/Dialog_MathInfoCard.cs
+++ b/Source/Dialogs/Dialog_MathInfoCard.cs
@@ -2,6 +2,7 @@
 using Verse;
 using RimWorld;
 using HarmonyLib;
+using Inventory;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
@@ -108,6 +109,9 @@ namespace CrunchyDuck.Math {
 			tabs.Add(new TabRecord("CD.M.infocard.categories".Translate(), () => tab = InfoCardTab.Categories, tab == InfoCardTab.Categories));
 			tabs.Add(new TabRecord("StatDefs", () => tab = InfoCardTab.StatDefs, tab == InfoCardTab.StatDefs));
 
+			if (Math.compositableLoadoutsSupportEnabled)
+				tabs.Add(new TabRecord("CD.M.infocard.compositable_loadouts".Translate(), () => tab = InfoCardTab.CompositableLoadouts, tab == InfoCardTab.CompositableLoadouts));
+
 			Rect label_area = new Rect(inRect);
 			label_area = label_area.ContractedBy(18f);
 			label_area.height = 34f;
@@ -132,6 +136,9 @@ namespace CrunchyDuck.Math {
 				statEntries = GetPawnsEntries();
 			else if (tab == InfoCardTab.StatDefs)
 				statEntries = GetStatDefsEntries();
+			else if (tab == InfoCardTab.CompositableLoadouts)
+				statEntries = GetCompositableLoadoutsEntries();
+			
 			statsCacheValues.SetValue(null, new List<string>());
 			statsCache.SetValue(null, statEntries);
 			StatsFinalize.Invoke(null, new object[] { statsCache.GetValue(null) });
@@ -160,7 +167,7 @@ namespace CrunchyDuck.Math {
 				display_priority--);
 			stats.Add(stat);
 
-
+			stats.Add(new StatDrawEntry(cat, "CD.M.infocard.basic.tutorials.stacks".Translate(), "", "CD.M.infocard.basic.tutorials.stacks.description".Translate(), display_priority--));
 			stats.Add(new StatDrawEntry(cat, "CD.M.infocard.basic.tutorials.variable_names".Translate(), "", "CD.M.infocard.basic.tutorials.variable_names.description".Translate(), display_priority--));
 			stats.Add(new StatDrawEntry(cat, "CD.M.infocard.basic.tutorials.itemcount".Translate(), "", "CD.M.infocard.basic.tutorials.itemcount.description".Translate(), display_priority--));
 			stats.Add(new StatDrawEntry(cat, "CD.M.infocard.basic.tutorials.doXTimes".Translate(), "", "CD.M.infocard.basic.tutorials.doXTimes.description".Translate(), display_priority--));
@@ -172,6 +179,7 @@ namespace CrunchyDuck.Math {
 			// nice thinking oken
 			// BEWARE THE HIDDEN HORRORS.
 			cat = catExamples;
+			stats.Add(new StatDrawEntry(cat, "​" + "CD.M.infocard.basic.examples.stacks".Translate(), "", "CD.M.infocard.basic.examples.stacks.description".Translate(), display_priority--));
 			stats.Add(new StatDrawEntry(cat, "​" + "CD.M.infocard.basic.examples.pawns".Translate(), "", "CD.M.infocard.basic.examples.pawns.description".Translate(), display_priority--));
 			stats.Add(new StatDrawEntry(cat, "​" + "CD.M.infocard.basic.examples.intake".Translate(), "", "CD.M.infocard.basic.examples.intake.description".Translate(), display_priority--));
 			stats.Add(new StatDrawEntry(cat, "​" + "CD.M.infocard.basic.examples.meals".Translate(), "", "CD.M.infocard.basic.examples.meals.description".Translate(), display_priority--));
@@ -273,6 +281,30 @@ namespace CrunchyDuck.Math {
 
 			return stats;
 		}
+
+		private List<StatDrawEntry> GetCompositableLoadoutsEntries() {
+			var stats = new List<StatDrawEntry>();
+			int display_priority = 10000;
+			
+			var cat = catIntroduction;
+			stats.Add(new StatDrawEntry(cat, "CD.M.infocard.compositable_loadouts".Translate(), "", "CD.M.infocard.compositable_loadouts.description".Translate(), display_priority--));
+			
+			cat = catExamples;
+			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
+			if (loadoutManager.tags.Count == 0) {
+				stats.Add(new StatDrawEntry(cat, "CD.M.infocard.compositable_loadouts.no_tags".Translate(), "", "CD.M.infocard.compositable_loadouts.no_tags.description".Translate(), display_priority--));
+			}
+			else {
+				var tagNames = new SortedSet<string>();
+				foreach (Tag tag in loadoutManager.tags) {
+					tagNames.Add(tag.name);
+				}
+				foreach (string tag in tagNames) {
+					stats.Add(new StatDrawEntry(cat, "CD.M.infocard.compositable_loadouts.tag".Translate(tag.ToParameter()), "", "CD.M.infocard.compositable_loadouts.tag.description".Translate(tag), display_priority--));
+				}
+			}
+			return stats;
+		}
 	}
 
 	public enum InfoCardTab {
@@ -280,5 +312,6 @@ namespace CrunchyDuck.Math {
 		Pawns,
 		Categories,
 		StatDefs,
+		CompositableLoadouts
 	}
 }

--- a/Source/Math.cs
+++ b/Source/Math.cs
@@ -39,6 +39,7 @@ namespace CrunchyDuck.Math {
 		public static Dictionary<string, (TraitDef traitDef, int index)> searchableTraits = new Dictionary<string, (TraitDef, int)>();
 
 		public static bool rimfactorySupportEnabled = false;
+		public static bool compositableLoadoutsSupportEnabled = false;
 
 		static Math() {
 			Check3rdPartyMods();
@@ -103,6 +104,12 @@ namespace CrunchyDuck.Math {
 		{
 			rimfactorySupportEnabled =
 				LoadedModManager.RunningModsListForReading.Any(mod => mod.PackageId == "spdskatr.projectrimfactory");
+
+			compositableLoadoutsSupportEnabled =
+				LoadedModManager.RunningModsListForReading.Any(mod => mod.PackageId == "wiri.compositableloadouts");
+
+			if (compositableLoadoutsSupportEnabled)
+				Log.Message("Math: Compositable Loadouts Support Enabled.");
 		}
 
 		private static void PerformPatches() {

--- a/Source/Math.csproj
+++ b/Source/Math.csproj
@@ -44,7 +44,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <Reference Include="Inventory">
-      <HintPath>G:\SteamLibrary\steamapps\workshop\content\294100\2679126859\1.4\Assemblies\Inventory.dll</HintPath>
+      <HintPath>..\..\..\..\..\workshop\content\294100\2679126859\1.4\Assemblies\Inventory.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="NCalc, Version=3.5.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Source/Math.csproj
+++ b/Source/Math.csproj
@@ -43,6 +43,10 @@
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
+    <Reference Include="Inventory">
+      <HintPath>G:\SteamLibrary\steamapps\workshop\content\294100\2679126859\1.4\Assemblies\Inventory.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="NCalc, Version=3.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Assemblies\NCalc.dll</HintPath>
@@ -67,6 +71,7 @@
     <Compile Include="Dialogs\Dialog_VariableList.cs" />
     <Compile Include="GUIExtensions.cs" />
     <Compile Include="MathFilters\CategoryFilter.cs" />
+    <Compile Include="MathFilters\CompositableLoadoutTagsFilter.cs" />
     <Compile Include="MathFilters\MathFilter.cs" />
     <Compile Include="MathFilters\PawnFilter.cs" />
     <Compile Include="MathFilters\ThingDefFilter.cs" />

--- a/Source/MathFilters/CompositableLoadoutTagsFilter.cs
+++ b/Source/MathFilters/CompositableLoadoutTagsFilter.cs
@@ -18,7 +18,7 @@ namespace CrunchyDuck.Math.MathFilters {
 			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
 			// This looks like it uses a for loop internally, and is cleaner.
 			// Also, since tag names are user defined, this will just return the first tag with the name, duplicate tag names are user error.
-			tagResult = loadoutManager.tags.Find(tag => name.Equals(tag.name, StringComparison.CurrentCultureIgnoreCase));
+			tagResult = loadoutManager.tags.Find(tag => tag.name.ToParameter() == name);
 			return tagResult != null;
 		}
 		

--- a/Source/MathFilters/CompositableLoadoutTagsFilter.cs
+++ b/Source/MathFilters/CompositableLoadoutTagsFilter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Inventory;
+using JetBrains.Annotations;
+using Verse;
+using RimWorld;
+
+namespace CrunchyDuck.Math.MathFilters {
+	class CompositableLoadoutTagsFilter : MathFilter {
+		public static HashSet<string> names = new HashSet<string> { "loadout tags", "lt" };
+		public override bool CanCount { get { return true; } }
+
+		private Tag tag;
+		private BillComponent bc;
+
+		[CanBeNull]
+		public static bool TryFindTagByName(string name, out Tag tagResult) {
+			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
+			// This looks like it uses a for loop internally, and is cleaner.
+			// Also, since tag names are user defined, this will just return the first tag with the name, duplicate tag names are user error.
+			tagResult = loadoutManager.tags.Find(tag => name.Equals(tag.name, StringComparison.CurrentCultureIgnoreCase));
+			return tagResult != null;
+		}
+		
+		public CompositableLoadoutTagsFilter(BillComponent bc, Tag tag) {
+			this.bc = bc;
+			this.tag = tag;
+		}
+
+		public override float Count() {
+			if (tag == null) {
+				return 0;
+			}
+			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
+			return loadoutManager.pawnTags[tag].Pawns.Count(p => p != null && !p.Dead && p.IsValidLoadoutHolder() && p.Map == bc.targetBill.Map && p.HostFaction == null);
+		}
+
+		public override ReturnType Parse(string command, out object result) {
+			throw new NotImplementedException();
+		}
+
+		//public override ReturnType ParseType(string command) {
+		//	throw new NotImplementedException();
+		//}
+	}
+}

--- a/Source/MathFilters/ThingFilter.cs
+++ b/Source/MathFilters/ThingFilter.cs
@@ -11,6 +11,7 @@ namespace CrunchyDuck.Math.MathFilters {
 		};
 		public static Dictionary<string, Func<Thing, float>> counterMethods = new Dictionary<string, Func<Thing, float>>() {
 			//{ "stack limit", t => t.def.stackLimit }
+			{"stacks", GetStacks}
 		};
 
 		public override bool CanCount { get { return true; } }
@@ -37,6 +38,11 @@ namespace CrunchyDuck.Math.MathFilters {
 				count += thing.stackCount;
 			}
 			return count;
+		}
+		
+		// This function will assume that every Thing in this ThingFilter is the same ThingDef.
+		public static float GetStacks(Thing thing) {
+			return ((float) thing.stackCount) / thing.def.stackLimit;
 		}
 
 		public override ReturnType Parse(string command, out object result) {


### PR DESCRIPTION
1. Add support for "thing.stacks" which evaluate how many stacks of a thing you have, with respect to the stack limit. This is because I often find myself dividing by the stack limit to measure stacks instead of individual item count.
3. Add a new MathFilter for Compositable Loadout support, this works by counting pawns with  a given tag. Pawn selection criteria is the same as the way the LoadoutManager counts pawns for the "X per tag" option. 

(2) Usage examples: "loadout tags.standard outfit" or "lt.standard outfit". In the event of tags with duplicated names, it will use the first.

(2) allows for more complex conditionals of the tag system compared to compositable loadout's "X per tag" setup, which is still broken with Math installed.

(2) isn't cached, because it's unlikely there will be enough tags or tagged pawns to make a noticeable slowdown during the Math tick, it just queries the LoadoutManager GameComp as required.