### PR TITLE
Remove Direct References to other mods.

### DIFF
--- a/Source/Dialogs/Dialog_MathInfoCard.cs
+++ b/Source/Dialogs/Dialog_MathInfoCard.cs
@@ -1,8 +1,8 @@
-﻿using UnityEngine;
+﻿using CrunchyDuck.Math.ModCompat;
+using UnityEngine;
 using Verse;
 using RimWorld;
 using HarmonyLib;
-using Inventory;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
@@ -290,14 +290,14 @@ namespace CrunchyDuck.Math {
 			stats.Add(new StatDrawEntry(cat, "CD.M.infocard.compositable_loadouts".Translate(), "", "CD.M.infocard.compositable_loadouts.description".Translate(), display_priority--));
 			
 			cat = catExamples;
-			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
-			if (loadoutManager.tags.Count == 0) {
+			IReadOnlyList<object> tags = CompositableLoadoutsSupport.GetTags(); 
+			if (tags.Count == 0) {
 				stats.Add(new StatDrawEntry(cat, "CD.M.infocard.compositable_loadouts.no_tags".Translate(), "", "CD.M.infocard.compositable_loadouts.no_tags.description".Translate(), display_priority--));
 			}
 			else {
 				var tagNames = new SortedSet<string>();
-				foreach (Tag tag in loadoutManager.tags) {
-					tagNames.Add(tag.name);
+				foreach (object tag in tags) {
+					tagNames.Add(CompositableLoadoutsSupport.GetTagName(tag));
 				}
 				foreach (string tag in tagNames) {
 					stats.Add(new StatDrawEntry(cat, "CD.M.infocard.compositable_loadouts.tag".Translate(tag.ToParameter()), "", "CD.M.infocard.compositable_loadouts.tag.description".Translate(tag), display_priority--));

--- a/Source/Math.cs
+++ b/Source/Math.cs
@@ -3,8 +3,10 @@ using HarmonyLib;
 using System.Reflection;
 using System.Collections.Generic;
 using Verse;
+using UnityEngine;
 using NCalc;
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace CrunchyDuck.Math {

--- a/Source/Math.cs
+++ b/Source/Math.cs
@@ -3,10 +3,8 @@ using HarmonyLib;
 using System.Reflection;
 using System.Collections.Generic;
 using Verse;
-using UnityEngine;
 using NCalc;
 using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace CrunchyDuck.Math {
@@ -108,6 +106,9 @@ namespace CrunchyDuck.Math {
 			compositableLoadoutsSupportEnabled =
 				LoadedModManager.RunningModsListForReading.Any(mod => mod.PackageId == "wiri.compositableloadouts");
 
+			if (rimfactorySupportEnabled)
+				Log.Message("Math: PRF support enabled.");
+			
 			if (compositableLoadoutsSupportEnabled)
 				Log.Message("Math: Compositable Loadouts Support Enabled.");
 		}
@@ -127,7 +128,6 @@ namespace CrunchyDuck.Math {
 			AddPatch(harmony, typeof(Patch_BillCopying));
 
 			if (rimfactorySupportEnabled)  {
-				Log.Message("Math: PRF support enabled.");
 				AddPatch(harmony, typeof(Patch_RimFactory_RecipeWorkerCounter_CountProducts));
 			}
 		}

--- a/Source/Math.csproj
+++ b/Source/Math.csproj
@@ -43,17 +43,9 @@
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <Reference Include="Inventory">
-      <HintPath>..\..\..\..\..\workshop\content\294100\2679126859\1.4\Assemblies\Inventory.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="NCalc, Version=3.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Assemblies\NCalc.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ProjectRimFactory">
-      <HintPath>..\..\..\..\..\workshop\content\294100\2033979700\Assemblies\ProjectRimFactory.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Core" />
@@ -76,6 +68,8 @@
     <Compile Include="MathFilters\PawnFilter.cs" />
     <Compile Include="MathFilters\ThingDefFilter.cs" />
     <Compile Include="MathFilters\ThingFilter.cs" />
+    <Compile Include="ModCompat\CompositableLoadoutsSupport.cs" />
+    <Compile Include="ModCompat\RimFactorySupport.cs" />
     <Compile Include="Patches\Bill_Production_DoConfigInterface_Patch.cs" />
     <Compile Include="Patches\CountProducts_Patch.cs" />
     <Compile Include="Dialogs\Dialog_MathBillConfig.cs" />

--- a/Source/MathFilters/CompositableLoadoutTagsFilter.cs
+++ b/Source/MathFilters/CompositableLoadoutTagsFilter.cs
@@ -1,29 +1,17 @@
-﻿using System;
+﻿using CrunchyDuck.Math.ModCompat;
+using System;
 using System.Collections.Generic;
-using Inventory;
-using JetBrains.Annotations;
-using Verse;
-using RimWorld;
+using System.Linq;
 
 namespace CrunchyDuck.Math.MathFilters {
 	class CompositableLoadoutTagsFilter : MathFilter {
 		public static HashSet<string> names = new HashSet<string> { "loadout tags", "lt" };
 		public override bool CanCount { get { return true; } }
 
-		// Use generic object type because otherwise exceptions can get thrown.
 		private object tag;
 		private BillComponent bc;
 
-		[CanBeNull]
-		public static bool TryFindTagByName(string name, out Tag tagResult) {
-			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
-			// This looks like it uses a for loop internally, and is cleaner.
-			// Also, since tag names are user defined, this will just return the first tag with the name, duplicate tag names are user error.
-			tagResult = loadoutManager.tags.Find(tag => tag.name.ToParameter() == name);
-			return tagResult != null;
-		}
-		
-		public CompositableLoadoutTagsFilter(BillComponent bc, Tag tag) {
+		public CompositableLoadoutTagsFilter(BillComponent bc, object tag) {
 			this.bc = bc;
 			this.tag = tag;
 		}
@@ -32,8 +20,7 @@ namespace CrunchyDuck.Math.MathFilters {
 			if (tag == null) {
 				return 0;
 			}
-			LoadoutManager loadoutManager = Current.Game.GetComponent<LoadoutManager>();
-			return loadoutManager.pawnTags[(Tag)tag].Pawns.Count(p => p != null && !p.Dead && p.IsValidLoadoutHolder() && p.Map == bc.targetBill.Map && p.HostFaction == null);
+			return CompositableLoadoutsSupport.GetPawnsWithTag(tag).Count(p => p != null && !p.Dead && CompositableLoadoutsSupport.IsValidLoadoutHolder(p) && p.Map == bc.targetBill.Map && p.HostFaction == null);
 		}
 
 		public override ReturnType Parse(string command, out object result) {

--- a/Source/ModCompat/CompositableLoadoutsSupport.cs
+++ b/Source/ModCompat/CompositableLoadoutsSupport.cs
@@ -1,0 +1,56 @@
+﻿using CrunchyDuck.Math.MathFilters;
+using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Verse;
+
+namespace CrunchyDuck.Math.ModCompat {
+	public class CompositableLoadoutsSupport {
+		private static Type LoadoutManagerType = Type.GetType("Inventory.LoadoutManager, Inventory");
+		private static Type LoadoutTagType = Type.GetType("Inventory.Tag, Inventory");
+		private static Type LoadoutUtilityType = Type.GetType("Inventory.Utility, Inventory");
+		private static AccessTools.FieldRef<GameComponent, IDictionary> LoadoutManagerPawnTagsField = AccessTools.FieldRefAccess<IDictionary>(LoadoutManagerType, "pawnTags");
+		private static AccessTools.FieldRef<object, string> TagNameField = AccessTools.FieldRefAccess<string>(LoadoutTagType, "name");
+		private static AccessTools.FieldRef<GameComponent, IReadOnlyList<object>> LoadoutManagerTagsField = AccessTools.FieldRefAccess<IReadOnlyList<object>>(LoadoutManagerType, "tags");
+
+		public static Func<Pawn, bool> IsValidLoadoutHolder = AccessTools.MethodDelegate<Func<Pawn, bool>>(
+			AccessTools.Method(LoadoutUtilityType, "IsValidLoadoutHolder"));
+		public static IReadOnlyList<Pawn> GetPawnsWithTag(object tag) {
+			return ((SerializablePawnList) LoadoutManagerPawnTagsField(GetLoadoutManager())[tag]).Pawns;
+		}
+
+		public static IReadOnlyList<object> GetTags() {
+			return LoadoutManagerTagsField(GetLoadoutManager());
+		}
+
+		public static string GetTagName(object tag) {
+			return TagNameField(tag);
+		}
+
+		private static GameComponent GetLoadoutManager() =>
+			Current.Game.GetComponent(LoadoutManagerType);
+
+		public static bool GetCompositableLoadoutFilter(string command, BillComponent bc, ref MathFilter filter) {
+			if (!Math.compositableLoadoutsSupportEnabled || !TryFindTagByName(command, out object tag))
+				return false;
+			filter = new CompositableLoadoutTagsFilter(bc, tag);
+			return true;
+		}
+		
+		public static bool TryFindTagByName(string name, out object tagResult) {
+			foreach (object tag in GetTags()) {
+				if (!TagMatchesParameterName(tag, name))
+					continue;
+				tagResult = tag;
+				return true;
+			}
+			tagResult = null;
+			return false;
+		}
+
+		private static bool TagMatchesParameterName(object tag, string parameterName) =>
+			TagNameField(tag).ToParameter() == parameterName;
+	}
+}

--- a/Source/ModCompat/RimFactorySupport.cs
+++ b/Source/ModCompat/RimFactorySupport.cs
@@ -1,0 +1,56 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Verse;
+
+namespace CrunchyDuck.Math.ModCompat {
+	public class RimFactorySupport {
+
+		private static Type PrfGameCompType { get; } = Type.GetType("ProjectRimFactory.PRFGameComponent, ProjectRimFactory");
+		private static Type PrfMapCompType { get; } = Type.GetType("ProjectRimFactory.Common.PRFMapComponent, ProjectRimFactory");
+		private static Type PrfAssemblerQueueType { get; } = Type.GetType("ProjectRimFactory.Common.HarmonyPatches.IAssemblerQueue, ProjectRimFactory");
+		private static Type PrfPatchStorageUtilType { get; } = Type.GetType("ProjectRimFactory.Common.HarmonyPatches.PatchStorageUtil, ProjectRimFactory");
+		private static Type PrfILinkableStorageParentType { get; } = Type.GetType("ProjectRimFactory.Storage.ILinkableStorageParent, ProjectRimFactory");
+		private static AccessTools.FieldRef<GameComponent, IReadOnlyList<object>> PrfGameCompAssemblerQueue = AccessTools.FieldRefAccess<IReadOnlyList<object>>(PrfGameCompType, "AssemblerQueue");
+		private static AccessTools.FieldRef<MapComponent, IReadOnlyList<object>> PrfMapCompColdStorageBuildings = AccessTools.FieldRefAccess<IReadOnlyList<object>>(PrfMapCompType, "ColdStorageBuildings");
+		
+		private static dynamic PrfStorageParentAdvancedIOAllowed = AccessTools.PropertyGetter(PrfILinkableStorageParentType, "AdvancedIOAllowed")
+			.CreateDelegate(Expression.GetDelegateType(PrfILinkableStorageParentType, typeof(bool)));
+		
+		private static dynamic PrfStorageParentStoredItems = AccessTools.PropertyGetter(PrfILinkableStorageParentType, "StoredItems")
+			.CreateDelegate(Expression.GetDelegateType(PrfILinkableStorageParentType, typeof(List<Thing>)));
+		
+		private static dynamic PrfAssemblerQueueMap = AccessTools.PropertyGetter(PrfAssemblerQueueType, "Map")
+			.CreateDelegate(Expression.GetDelegateType(PrfAssemblerQueueType, typeof(Map)));
+		
+		private static dynamic PrfGetAssemblerThingQueue = AccessTools.Method(PrfAssemblerQueueType, "GetThingQueue", Type.EmptyTypes)
+			.CreateDelegate(Expression.GetDelegateType(PrfAssemblerQueueType, typeof(List<Thing>)));
+
+		private static Func<Map, MapComponent> GetPrfMapComp = AccessTools.MethodDelegate<Func<Map, MapComponent>>(
+			AccessTools.Method(PrfPatchStorageUtilType, "GetPRFMapComponent", new[] { typeof(Map) }));
+		private static GameComponent GetPrfGameComp() => Current.Game.GetComponent(PrfGameCompType);
+		
+		// RimFactory CountProducts Support
+		public static List<Thing> GetThingsFromPRF(Map map, ThingDef def) {
+			// Adapted from PRF Patch_RecipeWorkerCounter_CountProducts
+			GameComponent prfGameComponent = GetPrfGameComp();
+			IEnumerable<Thing> assemblerQueuedThings = PrfGameCompAssemblerQueue(prfGameComponent)
+				.Where(assembler => PrfAssemblerQueueMap(assembler) == map)
+				.SelectMany(assembler => (IEnumerable<Thing>)PrfGetAssemblerThingQueue(assembler));
+
+			
+			MapComponent prfMapComp = GetPrfMapComp(map);
+			IEnumerable<Thing> coldStoredThings = PrfMapCompColdStorageBuildings(prfMapComp)
+				.Where(storageParent => !PrfStorageParentAdvancedIOAllowed(storageParent))
+				.SelectMany(storageParent => (IEnumerable<Thing>)PrfStorageParentStoredItems(storageParent));
+
+			return assemblerQueuedThings.Concat(coldStoredThings)
+				.Select(thing => thing.GetInnerIfMinified())
+				.Where(thing => thing.def == def)
+				.ToList();
+		}
+	}
+}

--- a/Source/ModCompat/RimFactorySupport.cs
+++ b/Source/ModCompat/RimFactorySupport.cs
@@ -3,7 +3,7 @@ using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Reflection;
 using Verse;
 
 namespace CrunchyDuck.Math.ModCompat {
@@ -14,22 +14,14 @@ namespace CrunchyDuck.Math.ModCompat {
 		private static Type PrfAssemblerQueueType { get; } = Type.GetType("ProjectRimFactory.Common.HarmonyPatches.IAssemblerQueue, ProjectRimFactory");
 		private static Type PrfPatchStorageUtilType { get; } = Type.GetType("ProjectRimFactory.Common.HarmonyPatches.PatchStorageUtil, ProjectRimFactory");
 		private static Type PrfILinkableStorageParentType { get; } = Type.GetType("ProjectRimFactory.Storage.ILinkableStorageParent, ProjectRimFactory");
-		private static AccessTools.FieldRef<GameComponent, IReadOnlyList<object>> PrfGameCompAssemblerQueue = AccessTools.FieldRefAccess<IReadOnlyList<object>>(PrfGameCompType, "AssemblerQueue");
-		private static AccessTools.FieldRef<MapComponent, IReadOnlyList<object>> PrfMapCompColdStorageBuildings = AccessTools.FieldRefAccess<IReadOnlyList<object>>(PrfMapCompType, "ColdStorageBuildings");
 		
-		private static dynamic PrfStorageParentAdvancedIOAllowed = AccessTools.PropertyGetter(PrfILinkableStorageParentType, "AdvancedIOAllowed")
-			.CreateDelegate(Expression.GetDelegateType(PrfILinkableStorageParentType, typeof(bool)));
-		
-		private static dynamic PrfStorageParentStoredItems = AccessTools.PropertyGetter(PrfILinkableStorageParentType, "StoredItems")
-			.CreateDelegate(Expression.GetDelegateType(PrfILinkableStorageParentType, typeof(List<Thing>)));
-		
-		private static dynamic PrfAssemblerQueueMap = AccessTools.PropertyGetter(PrfAssemblerQueueType, "Map")
-			.CreateDelegate(Expression.GetDelegateType(PrfAssemblerQueueType, typeof(Map)));
-		
-		private static dynamic PrfGetAssemblerThingQueue = AccessTools.Method(PrfAssemblerQueueType, "GetThingQueue", Type.EmptyTypes)
-			.CreateDelegate(Expression.GetDelegateType(PrfAssemblerQueueType, typeof(List<Thing>)));
-
-		private static Func<Map, MapComponent> GetPrfMapComp = AccessTools.MethodDelegate<Func<Map, MapComponent>>(
+		private static readonly AccessTools.FieldRef<GameComponent, IReadOnlyList<object>> PrfGameCompAssemblerQueue = AccessTools.FieldRefAccess<IReadOnlyList<object>>(PrfGameCompType, "AssemblerQueue");
+		private static readonly AccessTools.FieldRef<MapComponent, IReadOnlyList<object>> PrfMapCompColdStorageBuildings = AccessTools.FieldRefAccess<IReadOnlyList<object>>(PrfMapCompType, "ColdStorageBuildings");
+		private static readonly PropertyInfo PrfStorageParentAdvancedIoAllowed = AccessTools.Property(PrfILinkableStorageParentType, "AdvancedIOAllowed");
+		private static readonly PropertyInfo PrfStorageParentStoredItems = AccessTools.Property(PrfILinkableStorageParentType, "StoredItems");
+		private static readonly PropertyInfo PrfAssemblerQueueMap = AccessTools.Property(PrfAssemblerQueueType, "Map");
+		private static readonly MethodInfo PrfGetAssemblerThingQueue = AccessTools.Method(PrfAssemblerQueueType, "GetThingQueue", Type.EmptyTypes);
+		private static readonly Func<Map, MapComponent> GetPrfMapComp = AccessTools.MethodDelegate<Func<Map, MapComponent>>(
 			AccessTools.Method(PrfPatchStorageUtilType, "GetPRFMapComponent", new[] { typeof(Map) }));
 		private static GameComponent GetPrfGameComp() => Current.Game.GetComponent(PrfGameCompType);
 		
@@ -38,14 +30,14 @@ namespace CrunchyDuck.Math.ModCompat {
 			// Adapted from PRF Patch_RecipeWorkerCounter_CountProducts
 			GameComponent prfGameComponent = GetPrfGameComp();
 			IEnumerable<Thing> assemblerQueuedThings = PrfGameCompAssemblerQueue(prfGameComponent)
-				.Where(assembler => PrfAssemblerQueueMap(assembler) == map)
-				.SelectMany(assembler => (IEnumerable<Thing>)PrfGetAssemblerThingQueue(assembler));
+				.Where(assembler => PrfAssemblerQueueMap.GetValue(assembler) == map)
+				.SelectMany(assembler => (IEnumerable<Thing>)PrfGetAssemblerThingQueue.Invoke(assembler, null));
 
 			
 			MapComponent prfMapComp = GetPrfMapComp(map);
 			IEnumerable<Thing> coldStoredThings = PrfMapCompColdStorageBuildings(prfMapComp)
-				.Where(storageParent => !PrfStorageParentAdvancedIOAllowed(storageParent))
-				.SelectMany(storageParent => (IEnumerable<Thing>)PrfStorageParentStoredItems(storageParent));
+				.Where(storageParent => !(bool)PrfStorageParentAdvancedIoAllowed.GetValue(storageParent))
+				.SelectMany(storageParent => (IEnumerable<Thing>)PrfStorageParentStoredItems.GetValue(storageParent));
 
 			return assemblerQueuedThings.Concat(coldStoredThings)
 				.Select(thing => thing.GetInnerIfMinified())

--- a/Source/Patches/Patch_RimFactory_RecipeWorkerCounter_CountProducts.cs
+++ b/Source/Patches/Patch_RimFactory_RecipeWorkerCounter_CountProducts.cs
@@ -1,14 +1,14 @@
 ﻿using System.Reflection;
 using HarmonyLib;
-using ProjectRimFactory.Common.HarmonyPatches;
 using RimWorld;
-using Verse;
+using System;
 
 namespace CrunchyDuck.Math
 {
     public class Patch_RimFactory_RecipeWorkerCounter_CountProducts {
         public static MethodInfo Target() {
-            return AccessTools.Method(typeof(Patch_RecipeWorkerCounter_CountProducts), nameof(Patch_RecipeWorkerCounter_CountProducts.Postfix));
+            Type type = Type.GetType("ProjectRimFactory.Common.HarmonyPatches.Patch_RecipeWorkerCounter_CountProducts, ProjectRimFactory");
+            return AccessTools.Method(type, "Postfix");
         }
 
         public static bool Prefix(Bill_Production bill) {


### PR DESCRIPTION
Now using reflection and delegates to handle crossmod access.
All crossmod access is now in their own classes.

This has a few benefits:
1. No longer requires them to be present at build time.
2. Nothing will ever accidentally throw because of references to not present types on classes being introspected.
3. Cross mod stack traces should hopefully have the Support class in their stack trace, making it clearer it's a crossmod issue.